### PR TITLE
add double spends test

### DIFF
--- a/projects/pandocore/src/main/kotlin/pando/Blockchain.kt
+++ b/projects/pandocore/src/main/kotlin/pando/Blockchain.kt
@@ -6,12 +6,11 @@ import java.security.PublicKey
 data class Blockchain(
     val address: Address,
     val publicKey: PublicKey,
-    val privateKey: PrivateKey,
     val blocks: List<Block>
 )
 
-fun createNewBlockchain(address: Address, publicKey: PublicKey, privateKey: PrivateKey) =
-    Blockchain(address, publicKey, privateKey, listOf())
+fun createNewBlockchain(address: Address, publicKey: PublicKey) =
+    Blockchain(address, publicKey, listOf())
 
 fun getLastBlock(blockchain: Blockchain): Block? =
     if (blockchain.blocks.any())

--- a/projects/pandocore/src/test/kotlin/utility/Fixtures.kt
+++ b/projects/pandocore/src/test/kotlin/utility/Fixtures.kt
@@ -7,5 +7,5 @@ import java.security.PrivateKey
 
 fun createNewBlockchain(): Pair<Blockchain, PrivateKey> {
   val pair = generateAddressPair()
-  return Pair(pando.createNewBlockchain(pair.address, pair.keyPair.public, pair.keyPair.private), pair.keyPair.private)
+  return Pair(pando.createNewBlockchain(pair.address, pair.keyPair.public), pair.keyPair.private)
 }


### PR DESCRIPTION
the nodes have built in functionality at the moment that makes transactions less verbose than doing it without a node we may want to change it but I think the test gets the job done